### PR TITLE
Set another pair of curly brackets (mustaches) in the json so the mus…

### DIFF
--- a/src/main/resources/demo_scheduled.json
+++ b/src/main/resources/demo_scheduled.json
@@ -31,7 +31,7 @@
         },
         {
           "type": "mrkdwn",
-          "text": "*Zoom Link:*\n{{zoom_link}}"
+          "text": "*Zoom Link:*\n{{{zoom_link}}}"
         },
         {
           "type": "mrkdwn",


### PR DESCRIPTION
…tache compiler won't encode the Zoom link